### PR TITLE
ACA Reverse Proxy Config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,14 +20,9 @@ COPY --from=builder /opt/keycloak/ /opt/keycloak/
 
 # Configure ports
 #ENV KC_HOSTNAME=localhost
-ENV KC_PROXY=edge
-ENV KC_HTTP_PORT=8443
 ENV KC_HTTP_ENABLED=true
-ENV KC_HOSTNAME_PORT=8443
-ENV KC_HOSTNAME_STRICT_BACKCHANNEL=false
 ENV KC_PROXY_HEADERS=xforwarded
 ENV KC_HOSTNAME_STRICT=false
-ENV KC_HOSTNAME_STRICT_HTTPS=false
 
 # Configure admin user
 #ENV KEYCLOAK_ADMIN=admin
@@ -47,7 +42,8 @@ COPY providers/ /opt/keycloak/providers/
 # Copy custom configuration if needed
 COPY conf/ /opt/keycloak/conf/
 
-EXPOSE 8443
+EXPOSE 8080
+EXPOSE 9000
 
 # Start Keycloak in production mode
 ENTRYPOINT ["/opt/keycloak/bin/kc.sh", "start", "--import-realm"]

--- a/push.ps1
+++ b/push.ps1
@@ -55,7 +55,7 @@ az containerapp create `
     --registry-server "$ACR_NAME" `
     --min-replicas "$SCALE_MIN_REPLICAS" `
     --max-replicas "$SCALE_MAX_REPLICAS" `
-    --target-port 8443 `
+    --target-port 8080 `
     --env-vars KC_DB=$KC_DB `
 KC_DB_URL=$KC_DB_URL `
 KC_DB_USERNAME=$KC_DB_USERNAME `

--- a/push.sh
+++ b/push.sh
@@ -39,7 +39,7 @@ az containerapp create \
     --registry-server "$ACR_NAME" \
     --min-replicas "$SCALE_MIN_REPLICAS" \
     --max-replicas "$SCALE_MAX_REPLICAS" \
-    --target-port 8443 \
+    --target-port 8080 \
     --env-vars KC_DB=$KC_DB \
 KC_DB_URL=$KC_DB_URL \
 KC_DB_USERNAME=$KC_DB_USERNAME \


### PR DESCRIPTION
Remove env vars not needed for running behind reverse proxy with ssl termination.

Switch back to http port 8080. Leave HTTP Enabled as ACA already provides [ssl termination](https://learn.microsoft.com/en-us/azure/container-apps/networking?tabs=workload-profiles-env%2Cazure-cli#http-edge-proxy-behavior).